### PR TITLE
Overload makeError() to accept response only

### DIFF
--- a/src/android/InAppBillingV3.java
+++ b/src/android/InAppBillingV3.java
@@ -133,6 +133,10 @@ public class InAppBillingV3 extends CordovaPlugin {
     return makeError(message, resultCode, result.getMessage(), result.getResponse());
   }
 
+  protected JSONObject makeError(String message, Integer resultCode, Integer response) {
+    return makeError(message, resultCode, null, response);
+  }
+
   protected JSONObject makeError(String message, Integer resultCode, String text, Integer response) {
     if (message != null) {
       Log.d(TAG, "Error: " + message);
@@ -333,7 +337,7 @@ public class InAppBillingV3 extends CordovaPlugin {
     iabHelper.queryInventoryAsync(true, moreSkus, new IabHelper.QueryInventoryFinishedListener() {
       public void onQueryInventoryFinished(IabResult result, Inventory inventory) {
         if (result.isFailure()) {
-          callbackContext.error("Error retrieving SKU details");
+          callbackContext.error(result.getMessage());
           return;
         }
         JSONArray response = new JSONArray();
@@ -368,7 +372,7 @@ public class InAppBillingV3 extends CordovaPlugin {
       iabHelper.queryInventoryAsync(new IabHelper.QueryInventoryFinishedListener() {
         public void onQueryInventoryFinished(IabResult result, Inventory inventory) {
           if (result.isFailure()) {
-            callbackContext.error("Error retrieving purchase details");
+            callbackContext.error(makeError(result.getMessage(), null, result.getResponse()));
             return;
           }
           JSONArray response = new JSONArray();


### PR DESCRIPTION
Accept only the response and the message for cases where IAB does not return an error code but just a server response.

This response is then sent to cordova so the client can react on it.